### PR TITLE
Fixes the word Argument in link

### DIFF
--- a/js-arguments.md
+++ b/js-arguments.md
@@ -59,4 +59,4 @@ for (var i = 0; i < arguments.length; i++) {
 ```
 
 For more information on the optimization issues:  
-[Optimization Killers: Managing Arugments](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments)
+[Optimization Killers: Managing Arguments](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments)


### PR DESCRIPTION
Fixes the word Argument in text link, where it points to more
information about optimization issues and managing arguments.