### PR TITLE
Updated Santa Rosa country

### DIFF
--- a/List-of-Free-Code-Camp-city-based-Campsites.md
+++ b/List-of-Free-Code-Camp-city-based-Campsites.md
@@ -9,8 +9,7 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
   - [Luanda](https://www.facebook.com/groups/free.code.camp.luanda/)
 - Argentina
   - [Buenos Aires](https://www.facebook.com/groups/free.code.camp.buenos.aires/)
-  - [Cordoba](https://www.facebook.com/groups/free.code.camp.cordoba/)      
-  - [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
+  - [Cordoba](https://www.facebook.com/groups/free.code.camp.cordoba/)        
   - [Ticino](https://www.facebook.com/groups/free.code.camp.ticino/)
 - Armenia
   - [Yerevan](https://www.facebook.com/groups/free.code.camp.armenia/)
@@ -561,8 +560,9 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
     - [Sacramento](https://www.facebook.com/groups/free.code.camp.sacramento/)
     - [San Bernardino](https://www.facebook.com/groups/free.code.camp.san.bernardino/)
     - [San Diego](https://www.facebook.com/groups/free.code.camp.san.diego/)
-    - [San Luis Obispo](https://www.facebook.com/groups/free.code.camp.SLO/)
+    - [San Luis Obispo](https://www.facebook.com/groups/free.code.camp.SLO/)	
     - [Santa Clarita](https://www.facebook.com/groups/free.code.camp.santa.clarita/)
+	- [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
     - [South Los Angeles](https://www.facebook.com/groups/free.code.camp.southlosangeles/)
     - [Temecula](https://www.facebook.com/groups/free.code.camp.temecula/)
   - Colorado


### PR DESCRIPTION
Santa Rosa link belongs to California - United States, not to Argentina.
This PR resolve conflicts in PR #139.