### PR TITLE
Moved Santa Barbara Campsite from Honduras to California

### DIFF
--- a/List-of-Free-Code-Camp-city-based-Campsites.md
+++ b/List-of-Free-Code-Camp-city-based-Campsites.md
@@ -567,7 +567,7 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
     - [San Jose](https://www.facebook.com/groups/free.code.camp.san.jose)
     - [San Luis Obispo](https://www.facebook.com/groups/free.code.camp.SLO/)
     - [Santa Barbara](https://www.facebook.com/groups/free.code.camp.santa.barbara/)
-	  - [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
+    - [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
     - [South Los Angeles](https://www.facebook.com/groups/free.code.camp.southlosangeles/)
     - [Temecula](https://www.facebook.com/groups/free.code.camp.temecula/)
   - Colorado

--- a/List-of-Free-Code-Camp-city-based-Campsites.md
+++ b/List-of-Free-Code-Camp-city-based-Campsites.md
@@ -186,7 +186,6 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
 - Guatemala
   - [Guatemala City](https://www.facebook.com/groups/free.code.camp.guatemala/)
 - Honduras
-  - [Santa Barbara](https://www.facebook.com/groups/free.code.camp.santa.barbara/)
   - [Tegucigalpa](https://www.facebook.com/groups/free.code.camp.Honduras/)
 - Hong Kong
   - [Hong Kong](https://www.facebook.com/groups/free.code.camp.hk/)
@@ -567,7 +566,8 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
     - [San Francisco](https://www.facebook.com/groups/free.code.camp.san.francisco)
     - [San Jose](https://www.facebook.com/groups/free.code.camp.san.jose)
     - [San Luis Obispo](https://www.facebook.com/groups/free.code.camp.SLO/)
-	- [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
+    - [Santa Barbara](https://www.facebook.com/groups/free.code.camp.santa.barbara/)
+	  - [Santa Rosa](https://www.facebook.com/groups/free.code.camp.santa.rosa/)
     - [South Los Angeles](https://www.facebook.com/groups/free.code.camp.southlosangeles/)
     - [Temecula](https://www.facebook.com/groups/free.code.camp.temecula/)
   - Colorado
@@ -601,7 +601,7 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
     - [Columbus](https://www.facebook.com/groups/free.code.camp.columbus.georgia/)
     - [Savannah](https://www.facebook.com/groups/free.code.camp.savannah/)
     - [Valdosta](https://www.facebook.com/groups/free.code.camp.valdosta/)
-  - Hawaii 
+  - Hawaii
     - [Oahu](https://www.facebook.com/groups/free.code.camp.oahu.hawaii/)
   - Idaho
     - [Boise](https://www.facebook.com/groups/free.code.camp.boise)


### PR DESCRIPTION
Related to #164

Also aligned Santa Rosa with other California campsite bullet points.