### PR TITLE
Fix typo Congradulations

### DIFF
--- a/How-To-Fork-And-Maintain-a-Local-Instance-of-Free-Code-Camp.md
+++ b/How-To-Fork-And-Maintain-a-Local-Instance-of-Free-Code-Camp.md
@@ -42,7 +42,7 @@ This will download the entire FCC repo to your projects directory.
 1. Add a remote to the official FCC repo:  
 `git remote add upstream https://github.com/FreeCodeCamp/FreeCodeCamp.git`
 
-Congradulations, you now have a local copy of the FCC repo!
+Congratulations, you now have a local copy of the FCC repo!
 
 # Maintaining your Fork
 Now that you have a copy of your fork, there is work you will need to do to keep it current.


### PR DESCRIPTION
Fixed spelling of 'Congradulations' to 'Congratulations'