### PR TITLE
Islamanad removed from Afghanistan

### DIFF
--- a/List-of-Free-Code-Camp-city-based-Campsites.md
+++ b/List-of-Free-Code-Camp-city-based-Campsites.md
@@ -6,7 +6,6 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
 
 - Afghanistan
   - [Kabul](https://www.facebook.com/groups/free.code.camp.kabul/)
-  - [Islamabad](https://www.facebook.com/groups/free.code.camp.islamabad/)
 - Albania
   - [Tirana](https://www.facebook.com/groups/free.code.camp.tirana/)
 - Algeria
@@ -184,8 +183,8 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
   - [Milton Keynes](https://www.facebook.com/groups/free.code.camp.milton.keynes/)
   - [Norfolk](https://www.facebook.com/groups/free.code.camp.norfolk/)  
   - [Reading](https://www.facebook.com/groups/free.code.camp.reading/)
-  - [Sheffield](https://www.facebook.com/groups/free.code.camp.sheffield/) 
-  - [Southampton](https://www.facebook.com/groups/FCC.Southampton/) 
+  - [Sheffield](https://www.facebook.com/groups/free.code.camp.sheffield/)
+  - [Southampton](https://www.facebook.com/groups/FCC.Southampton/)
   - [Stoke-on-Trent](https://www.facebook.com/groups/free.code.camp.stoke.on.trent/)
   - [Warrington](https://www.facebook.com/groups/free.code.camp.warrington/)
   - [Worcester](https://www.facebook.com/groups/free.code.camp.worcester/)  
@@ -200,7 +199,7 @@ If your city isn't listed here, you should [[create a Campsite for your city|How
   - [Helsinki](https://www.facebook.com/groups/free.code.camp.helsinki/)
   - [Jyväskylä](https://www.facebook.com/groups/free.code.camp.jyvaskyla/)
   - [Lappeenranta](https://www.facebook.com/groups/free.code.camp.lappeenranta/)
-  - [Tampere](https://www.facebook.com/groups/Free.Code.Camp.Tampere/) 
+  - [Tampere](https://www.facebook.com/groups/Free.Code.Camp.Tampere/)
   - [Turku](https://www.facebook.com/groups/free.code.camp.turku/)    
 - France
   - [Dax](https://www.facebook.com/groups/509612812554265/)


### PR DESCRIPTION
I removed Islamabad from Afghanistan as it is not in Afghanistan.

It was already present under Pakistan. 