### PR TITLE
updated curriculum completion time

### DIFF
--- a/How-Long-Free-Code-Camp-Takes.md
+++ b/How-Long-Free-Code-Camp-Takes.md
@@ -1,10 +1,10 @@
-It takes about 1,600 hours to complete Free Code Camp.
+It takes about 2,080 hours to complete Free Code Camp.
 
 Free Code Camp is fully online, and there will always be other people at your skill level that you can pair program with, so you can learn at your own pace. Here are some example coding schedules:
 
 Time budgeted | Hours per week | Weeks to complete
 --- | --- | ---
-Weekends | 10 hours/week | 160 weeks (36 months)
-Nights and Weekends | 20 hours/week | 80 weeks (18 months)
-Full time | 40 hours/week | 40 weeks (9 months)
-Traditional Bootcamp Pacing | 80 hours/week | 20 weeks (5 months)
+Weekends | 10 hours/week | 208 weeks (48 months)
+Nights and Weekends | 20 hours/week | 104 weeks (24 months)
+Full time | 40 hours/week | 52 weeks (12 months)
+Traditional Bootcamp Pacing | 80 hours/week | 26 weeks (6 months)


### PR DESCRIPTION
Updated how long Free Code Camp takes to reflect latest curriculum changes.

*Changed 1,600 hours to 2,080 hours.
*Recalculated weeks to complete based on new hours.