### PR TITLE
Enhanced description about "return" statements in JS

### DIFF
--- a/Waypoint-Return-A-Value-From-A-Function-With-Return.md
+++ b/Waypoint-Return-A-Value-From-A-Function-With-Return.md
@@ -12,3 +12,5 @@ var answer = plusThree(5); // 8
 ```
 
 `plusThree` takes an `argument` for `num` and returns a value equal to `num + 3`.
+
+A `return` statement will also end the execution of it's parent function. Hence, any statements inside a function scope after a `return` statement will not be executed. In case of multiple `return` statements in a function, only the first one will get executed.

--- a/Waypoint-Use-Conditional-Logic-with-If-Else-Statements.md
+++ b/Waypoint-Use-Conditional-Logic-with-If-Else-Statements.md
@@ -16,4 +16,4 @@ function test(myVal) {
 }
 ```
 
-If `myVal` is greater than `10`, the function will return `"Greater Than"`. If it is not, the function will return `"Not Greater Than"`.
+If `myVal` is greater than `10`, the function will return `"Greater Than"`. If it is not, the function will return `"Not Greater Than"`. Both `return` statements will never get executed because as soon as the first one is encountered, the execution exits the function and returns control to where the function was called.


### PR DESCRIPTION
While doing the challenges in order, I didn’t encounter the “stop
execution and exit” property of return statements described anywhere.
So, while doing this
[challenge](http://www.freecodecamp.com/challenges/use-conditional-logic-with-if-statements) I figured that a camper might be confused as to
why the second statement won’t be executed if the condition is true.
Hence, I decided to add that part in the wiki in case someone looks for
it.