### PR TITLE
Code Solution 2 corrected.

### DIFF
--- a/Bonfire-Drop-it.md
+++ b/Bonfire-Drop-it.md
@@ -44,7 +44,7 @@ drop([1, 2, 3], function(n) {return n < 3; });
 ## Code Solution 2:
 ```js
 function drop(arr, func) {
-  return arr.slice(arr.findIndex(func) >= 0 && arr.findIndex(func), arr.length);
+  return arr.slice(arr.findIndex(func) >= 0 ? arr.findIndex(func): arr.length, arr.length);
 }
 
 drop([1, 2, 3, 4], function(n) {return n >= 3;});
@@ -53,7 +53,7 @@ drop([1, 2, 3, 4], function(n) {return n >= 3;});
 # Code Explanation:
 - Use ES6 `findIndex()` function to  find the index of the element that passes the condition
 - Slice the array from the found index until the end
-- There is one edge case! if the condition is not met against any of the elements 'findIndex' will return `-1` which messes up the input to `slice()`. In this case use a simple conditional operator to return `false` instead of `-1`. For more info see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator
+- There is one edge case! if the condition is not met against any of the elements 'findIndex' will return `-1` which messes up the input to `slice()`. In this case use a simple conditional operator to return `false` instead of `-1`. And the ternary operator (?:) returns the found index of required elements when the condition is `ture`, and the length of the array otherwise so that the return value is an empty array as is instructed. For more info see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator
 
 
 ## Code Solution 3:


### PR DESCRIPTION
The previous version fails the test case: `drop([1, 2, 3, 4], function(n) {return n > 5;}) should return [].` Because `arr.findIndex(func) >= 0 && arr.findIndex(func)` returns `false` in this case rather than a value. With `arr.findIndex(func) >= 0 ? arr.findIndex(func): arr.length`, the length of the array is returned thus `arr.slice()` returns an empty array.