### PR TITLE
Better header for Code Formatting

### DIFF
--- a/code-formatting.md
+++ b/code-formatting.md
@@ -1,13 +1,13 @@
-### Inline code
-This an inline **\`**`<paste code here>`**\`** code formatting with a single backtick(\`) at *start* and *end* around the `code`.
-
-### Code Block
+### Multi line Code
 **\`\`\`js** ⇦ Type 3 backticks and then press `[shift + enter ⏎]` (type js or html or css)
 ```text
 <paste your code here>,
 then press [shift + enter ⏎]
 ```
 **\`\`\`** ⇦ Type 3 backticks, then press `[enter ⏎]`
+
+### Single line Code
+This an inline **\`**`<paste code here>`**\`** code formatting with a single backtick(\`) at *start* and *end* around the `code`.
 
 See also: ☛ [**How to type Backticks**](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/code-formatting#typing-backticks) | ☯ [Compose Mode](https://gitter.zendesk.com/hc/en-us/articles/201302311-Compose-mode) | ❄ [Gitter Formatting Basics](https://gitter.zendesk.com/hc/en-us/articles/200176682-Markdown-basics)
 


### PR DESCRIPTION
People are too lazy to read the whole thing. They just want to paste their code in pretty format ASAP.

- Moved the multi-line formatting method to top so that people don't accidentally use the single line formatting.
- Modified the heading so that it better shows the intended behavior.