### PR TITLE
Add Python Resources Page

### DIFF
--- a/Python-Resources.md
+++ b/Python-Resources.md
@@ -1,0 +1,36 @@
+# Python Resources
+
+[Home](Python)
+
+## Tutorials
+
+* [Python Official Tutorials](https://docs.python.org/3/tutorial/)
+* [The Hitchhiker's Guide to Python](https://python-guide.readthedocs.org/en/latest/)
+* [Google Python Class](https://developers.google.com/edu/python/)
+* [Learn Python the Hard Way](http://learnpythonthehardway.org/book/)
+* [Think Python](http://www.greenteapress.com/thinkpython/html/index.html)
+* [Learn Python in X minutes](https://learnxinyminutes.com/docs/python/)
+* [Learn Python 3 in X minutes](https://learnxinyminutes.com/docs/python3/)
+* [Dive into Python 3](http://www.diveintopython3.net/)
+* [Full Stack Python](http://www.fullstackpython.com/)
+* [Automate the Boring Stuff with Python](https://automatetheboringstuff.com/)
+* [Python REPL in Browser](https://repl.it/languages/python3)
+* [Visual Python Code Walkthrough](http://pythontutor.com/)
+
+## Challenges
+
+* [Python Koans](https://github.com/gregmalcolm/python_koans)
+* [Exercism Python Challenges](http://exercism.io/languages/python)
+* [CodingBat Python Challenges](http://codingbat.com/python)
+* [Learn Python Interactively](http://www.learnpython.org/)
+* [Project Euler](http://projecteuler.net/)
+* [Rosalind Python Bio-informatics Problems](http://rosalind.info/problems/locations/)
+* [Python Elevator Challenge](https://github.com/mshang/python-elevator-challenge)
+* [CoderByte Challenges](https://coderbyte.com/)
+
+## Community
+
+* [Awesome Python](https://github.com/vinta/awesome-python)
+* [/r/Python](https://www.reddit.com/r/python)
+* [/r/LearnPython](https://www.reddit.com/r/learnpython)
+* [Planet Python](http://planetpython.org/)


### PR DESCRIPTION
As per discussion with @alayek, we found that most of the newcomers in Python Gitter channel are requesting resources and challenges to practice Python until the FCC challenges are up. Therefore I have curated a list of un-opinionated Python tutorials and Challenges for the newbies to try out.

Requesting @QuincyLarson to review. Since these links are external so please review them as to which ones should be added or which one shouldn't be. If needed I am happy to add more links.

Tagging @Rafase282 