### PR TITLE
Renamed Algorithm Drop It filename and fixed Solution 3

### DIFF
--- a/Algorithm-Drop-It.md
+++ b/Algorithm-Drop-It.md
@@ -59,7 +59,7 @@ drop([1, 2, 3, 4], function(n) {return n >= 3;});
 
 ```js
 function drop(arr, func) {
-  while(arr.length > 0 && !func(arr[0]))
+  while(arr.length > 0 && !func(arr[0])) {
     arr.shift();
   }
   return arr;


### PR DESCRIPTION
Renamed the filename to our convention and added the missing `{` that was removed n solution 3.

From #519 #518 #513 