### PR TITLE
Article: Untrack files from .gitignore

### DIFF
--- a/Ignore-Files-Committed-To-Git-Repo.md
+++ b/Ignore-Files-Committed-To-Git-Repo.md
@@ -1,0 +1,20 @@
+# Untrack files previously committed from new .gitignore
+To untrack a _single_ file, ie stop tracking the file but not delete it from the system use:
+
+`git rm --cached filename`
+
+To untrack _every_ file in `.gitignore`:
+
+First **commit** any outstanding code changes, and then run:
+
+`git rm -r --cached`
+
+This removes any changed files from the index(staging area), then run:
+
+`git add .`
+
+Commit it:
+
+`git commit -m ".gitignore is now working"`
+
+To undo `git rm --cached filename`, use `git add filename`


### PR DESCRIPTION
Wiki article for issue #367: untrack files previously committed from new .gitignore

Rename Ignore-files-committed-to-git-repo.md to Ignore-Files-Committed-To-Git-Repo.md

Uses proper markdown

Also fixed some typos.
closes #570