### PR TITLE
Text improvements - how to create a campsite

### DIFF
--- a/How-to-create-a-Campsite-for-your-city.md
+++ b/How-to-create-a-Campsite-for-your-city.md
@@ -1,9 +1,9 @@
-If you didn't see your city on [our list of Campsites](https://github.com/FreeCodeCamp/freecodecamp/wiki/List-of-Free-Code-Camp-city-based-Campsites), you should create your own Facebook group for your city.<br>
+If you didn't see your city on [our list of Campsites](https://github.com/FreeCodeCamp/freecodecamp/wiki/List-of-Free-Code-Camp-city-based-Campsites), you should create your own Facebook group.<br>
 We like keeping things as local as possible, so please create groups only for cities, or even smaller areas. 
 
 Please, do not create campsites for a whole State/province/department/county/etc. as they will not be added to the list.
-
-<br> 
+------
+<br>
 Now, to the fun part!
 It's easy, just follow these steps: 
 - Sign in to Facebook. 
@@ -14,14 +14,14 @@ It's easy, just follow these steps:
 <br>
 - Set the group name as "Free Code Camp" plus the proper name of your city.<br>Avoid using slang terms such as "Philly" for "Philadelphia". If your city is not the biggest city that uses its name, also include the state or province. For example, the Free Code Camp group in Paris, France should be called "Free Code Camp Paris". The Free Code Camp group in Paris, Texas should be called "Free Code Camp Paris, Texas".<br>If you are in North America, we suggest you add the initials of your state/province here.
 - Set your group to public. 
-- You'll need to add at least one person in order to create the group. Add [Justin](https://www.facebook.com/FCC.campsiteCounsellor)!, you can do so by using his email `fcc.campsitecounsellor@facebook.com`.
+- You'll need to add at least one person in order to create the group. Why not add [Justin](https://www.facebook.com/FCC.campsiteCounsellor)!? Furthermore, if you make him an admin, he'll be able to assist you in managing your members and events.
 
 ![A screenshot of the Facebook group creation modal saying that your group name should be Free Code Camp plus your city name, that your group should be public, and that you need to invite at least one Facebook friend.](https://www.evernote.com/shard/s116/sh/4ed3197c-db1b-4103-a040-b42482ad232a/6c34948ebe12c57f0b7a54d7b2222ab3/deep/0/Facebook.png)
 
 <br>
 - Choose the graduation cap icon to indicate that this group is related to a school. 
 
-![a screenshot telling you to choose the graduation icon, which is on the forth row of icons, seven icons from the left.](https://www.evernote.com/shard/s116/sh/00e461b3-e0a8-4ecd-9cbf-8b0ae9de75d1/59c4e9f25672b1b2ca2d7e6b06d55e0b/deep/0/Facebook.png)
+![A screenshot telling you to choose the graduation icon, which is on the forth row of icons, seven icons from the left.](https://www.evernote.com/shard/s116/sh/00e461b3-e0a8-4ecd-9cbf-8b0ae9de75d1/59c4e9f25672b1b2ca2d7e6b06d55e0b/deep/0/Facebook.png)
 
 <br>
 - Click the "..." menu, then click "Edit group settings" in the dropdown menu. 
@@ -30,14 +30,12 @@ It's easy, just follow these steps:
 
 <br>
 - Set the group's privacy setting to public. 
-- Set your group's membership approval to where any member can add or approve members ![a screenshot showing the Facebook settings panel and where you can click to set the group to public and allow all members to be able to add or approve members
-
-![A screen shot showing you the group description box on the Facebook page.](https://www.evernote.com/l/AHTs6Ec_hylKyYWVhpZonOHPn8j8I5ydgv4B/image.png)
+- Set your group's membership approval to where any member can add or approve members ![a screenshot showing the Facebook settings panel and where you can click to set the group to public and allow all members to be able to add or approve members](https://www.evernote.com/l/AHTs6Ec_hylKyYWVhpZonOHPn8j8I5ydgv4B/image.png)
 
 <br>
 - Click the "Customize Address" button.
 - Enter "free.code.camp.your.city" with each word separated by periods. 
-<br><br>**(Not "your.city"! this is just an example)**
+<br><br>**Example: free.code.camp.london<br>(Not "your.london" or "your.city.london"!)**
 
 ![a screenshot telling you to enter free.code.camp.your.city.name with each word seperated by periods.](https://www.evernote.com/shard/s116/sh/357b1bd9-7c40-4f72-8a9a-d918e632a5e8/c4714ca59360b2517dfffe90c60b1556/deep/0/Free-Code-Camp-Testland.png)
 
@@ -53,6 +51,8 @@ It's easy, just follow these steps:
 
 <br>
 - And finally, [message Justin (@hallaathrad on Gitter)](https://gitter.im/hallaathrad) with a link to your city's group page. He'll include it in the list.
-- Join our [Local Leaders Facebook group](https://www.facebook.com/groups/freecodecampers/), where we share ideas about involving campers in your city. 
 
-If you don't have a Facebook account, we strongly recommend you create one, even if it's just for the purpose of coordinating with campers in your city through this group. 
+**Additional tips:**
+- Join our [Local Leaders Facebook group](https://www.facebook.com/groups/freecodecampers/), where we share ideas about involving campers in your city. 
+- Read [this article](https://medium.freecodecamp.com/jump-start-your-local-campsite-with-coffee-and-code-a8d1a57d30e#) and see if you can set up your Campsite's first Coffee and Code.
+- Some [ideas on getting more people](https://medium.freecodecamp.com/growth-hacking-your-free-code-camp-group-8cf76300a5d1#) involved with your Campsite: 


### PR DESCRIPTION
General rephrasing to try to help campers understand the process a bit better:
- People still make URLs like free.code.camp.your.san.francisco
- Adding me as a group Admin makes it easier to reactivate campsites by getting a new leader rather than creating new ones. It sucks that [these](https://github.com/FreeCodeCamp/wiki/issues/304) will have to be removed for that reason.
- Making the oboarding articles easy to find as soon as you create the campsite is helpful, but knowing where to go find them again is invaluable... therefor, here they are.