### PR TITLE
Add FCC Git room to official list

### DIFF
--- a/Official-Free-Code-Camp-Chat-Rooms.md
+++ b/Official-Free-Code-Camp-Chat-Rooms.md
@@ -1,33 +1,33 @@
-The following are our official chat rooms.    
+The following are our official chat rooms.
 
-**Please note that all chat rooms listed here are publicly accessible and indexed by search engines, so only share email addresses or other sensitive information in private messages.**    
+**Please note that all chat rooms listed here are publicly accessible and indexed by search engines, so only share email addresses or other sensitive information in private messages.**
 
-| Chat Room | Description |    
-| --- | --- |    
-| [FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp) | our main chat room - hang out and chat about life and learning to code |    
-| [Help](https://gitter.im/freecodecamp/Help) | get help with our HTML, CSS and jQuery challenges from your fellow campers |   
-| [HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) | get help with our JavaScript and algorithm challenges from your fellow campers |    
-| [HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) | get help with our front end projects from your fellow campers |    
-| [HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) | get help with our data visualization projects from your fellow campers |    
-| [HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) | get help with our back end projects from your fellow campers |    
-| [Python](https://gitter.im/FreeCodeCamp/python) | get help doing our back end projects in Python, from your fellow campers |    
-| [Java](https://gitter.im/FreeCodeCamp/java) | get help doing our back end projects in Java, from your fellow campers |    
-| [Ruby](https://gitter.im/FreeCodeCamp/ruby) | get help doing our back end projects in Ruby, from your fellow campers |    
-| [PHP](https://gitter.im/FreeCodeCamp/php) | get help doing our back end projects in PHP, from your fellow campers |  
-| [Go](https://gitter.im/FreeCodeCamp/go) | get help doing our back end projects in Go, from your fellow campers | 
+| Chat Room | Description |
+| --- | --- |
+| [FreeCodeCamp](https://gitter.im/freecodecamp/FreeCodeCamp) | our main chat room - hang out and chat about life and learning to code |
+| [Help](https://gitter.im/freecodecamp/Help) | get help with our HTML, CSS and jQuery challenges from your fellow campers |
+| [HelpJavaScript](https://gitter.im/freecodecamp/HelpJavaScript) | get help with our JavaScript and algorithm challenges from your fellow campers |
+| [HelpFrontEnd](https://gitter.im/freecodecamp/HelpFrontEnd) | get help with our front end projects from your fellow campers |
+| [HelpDataViz](https://gitter.im/freecodecamp/HelpDataViz) | get help with our data visualization projects from your fellow campers |
+| [HelpBackEnd](https://gitter.im/freecodecamp/HelpBackEnd) | get help with our back end projects from your fellow campers |
+| [Python](https://gitter.im/FreeCodeCamp/python) | get help doing our back end projects in Python, from your fellow campers |
+| [Java](https://gitter.im/FreeCodeCamp/java) | get help doing our back end projects in Java, from your fellow campers |
+| [Ruby](https://gitter.im/FreeCodeCamp/ruby) | get help doing our back end projects in Ruby, from your fellow campers |
+| [PHP](https://gitter.im/FreeCodeCamp/php) | get help doing our back end projects in PHP, from your fellow campers |
+| [Go](https://gitter.im/FreeCodeCamp/go) | get help doing our back end projects in Go, from your fellow campers |
 | [Elixir](https://gitter.im/FreeCodeCamp/elixir) | get help doing our back end projects in Elixir, from your fellow campers |
 | [.NET](https://gitter.im/FreeCodeCamp/dotnet) | get help doing our back end projects in Microsoft .NET framework, from your fellow campers |
-| [Linux](https://gitter.im/FreeCodeCamp/linux) | get help with using Linux, from your fellow campers | 
-| [SQL](https://gitter.im/FreeCodeCamp/sql) | get help on relational databases and SQL, from your fellow campers |    
-| [CodeReview](https://gitter.im/freecodecamp/CodeReview) | give and receive constructive feedback from your fellow campers on your projects |    
-| [YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) | learning to code is hard - share your feelings and get moral support here |    
-| [CodingJobs](https://gitter.im/freecodecamp/CodingJobs) | chat about the process of getting a coding job, such as portfolios, networking, and interviewing |    
-| [Casual](https://gitter.im/freecodecamp/Casual) | you can chat about your non-coding interests with other campers here |   
-| [LiveCoding](https://gitter.im/freecodecamp/LiveCoding) | get set up to code live on our popular twitch.tv channel |    
-| [CurriculumDevelopment](https://gitter.im/freecodecamp/CurriculumDevelopment) | help us improve our open source curriculum |    
-| [DataScience](https://gitter.im/freecodecamp/DataScience) | help us understand our gigs and gigs of public data |    
+| [Linux](https://gitter.im/FreeCodeCamp/linux) | get help with using Linux, from your fellow campers |
+| [SQL](https://gitter.im/FreeCodeCamp/sql) | get help on relational databases and SQL, from your fellow campers |
+| [CodeReview](https://gitter.im/freecodecamp/CodeReview) | give and receive constructive feedback from your fellow campers on your projects |
+| [YouCanDoThis](https://gitter.im/freecodecamp/YouCanDoThis) | learning to code is hard - share your feelings and get moral support here |
+| [CodingJobs](https://gitter.im/freecodecamp/CodingJobs) | chat about the process of getting a coding job, such as portfolios, networking, and interviewing |
+| [Casual](https://gitter.im/freecodecamp/Casual) | you can chat about your non-coding interests with other campers here |
+| [LiveCoding](https://gitter.im/freecodecamp/LiveCoding) | get set up to code live on our popular twitch.tv channel |
+| [CurriculumDevelopment](https://gitter.im/freecodecamp/CurriculumDevelopment) | help us improve our open source curriculum |
+| [DataScience](https://gitter.im/freecodecamp/DataScience) | help us understand our gigs and gigs of public data |
 
 
-By joining these chat rooms, you accept our [Code of Conduct](https://github.com/FreeCodeCamp/freecodecamp/wiki/Code-of-Conduct).    
+By joining these chat rooms, you accept our [Code of Conduct](https://github.com/FreeCodeCamp/freecodecamp/wiki/Code-of-Conduct).
 
 If you also want to hang out with other campers in person, be sure to join a [Campsite in your city](List-of-Free-Code-Camp-city-based-Campsites-and-Chat-rooms).

--- a/Official-Free-Code-Camp-Chat-Rooms.md
+++ b/Official-Free-Code-Camp-Chat-Rooms.md
@@ -14,6 +14,7 @@ The following are our official chat rooms.
 | [Java](https://gitter.im/FreeCodeCamp/java) | get help doing our back end projects in Java, from your fellow campers |
 | [Ruby](https://gitter.im/FreeCodeCamp/ruby) | get help doing our back end projects in Ruby, from your fellow campers |
 | [PHP](https://gitter.im/FreeCodeCamp/php) | get help doing our back end projects in PHP, from your fellow campers |
+| [Git](https://gitter.im/FreeCodeCamp/Git) | get help related to everything about Git Version Control, from your fellow campers |
 | [Go](https://gitter.im/FreeCodeCamp/go) | get help doing our back end projects in Go, from your fellow campers |
 | [Elixir](https://gitter.im/FreeCodeCamp/elixir) | get help doing our back end projects in Elixir, from your fellow campers |
 | [.NET](https://gitter.im/FreeCodeCamp/dotnet) | get help doing our back end projects in Microsoft .NET framework, from your fellow campers |


### PR DESCRIPTION
- Fix trailing white spaces and EOL characters.
- Add <kbd><a href="https://gitter.im/FreeCodeCamp/Git"><img src="http://i.imgur.com/ThSWa6Y.png?2"> <b>FreeCodeCamp/Git</b></a></kbd> Room to official list of rooms.