### PR TITLE
Removed Camper News Option

### DIFF
--- a/Brownie-Points.md
+++ b/Brownie-Points.md
@@ -2,10 +2,9 @@ The number beside your picture on Free Code Camp tells you how many Brownie Poin
 
 ![A user profile picture next to a with Brownie Points score](http://i.imgur.com/SsvbkDH.png)
 
-There are three ways you can get Brownie Points:
+There are two ways you can get Brownie Points:
 
 1. Complete challenges - you get one point per challenge you complete    
-1. Post relevant links on [Camper News](Camper-News) - you get 1 point for posting a link, and another point for each upvote your link gets    
 1. Help other campers in chat - each time you help another camper and they thank you (by typing "thanks @yourname"), you will get a point    
 
 > Brownie Points help you look like the kind of person who codes a lot, shares relevant links, and helps people. 


### PR DESCRIPTION
Noticed that posting on camper news was still listed as an option for getting brownie points