### PR TITLE
Added link to Gitter.im rooms

### DIFF
--- a/Gitter.md
+++ b/Gitter.md
@@ -6,4 +6,6 @@
 
 Free Code Camp has hundreds of Gitter rooms. These are accessible through Gitter's website, as well as [desktop and mobile apps](https://gitter.im/apps).
 
+You can view [all of our rooms](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki/Official-Free-Code-Camp-Chat-Rooms) and join the ones you'd like to. 
+
 Gitter allows you to share [formatted code](https://github.com/FreeCodeCamp/freecodecamp/wiki/Pasting-Code-in-Gitter) with fellow campers.


### PR DESCRIPTION
File Gitter.md
Filepath FreeCodeCamp/wiki/Gitter.md

This is my first time contributing to FreeCodeCamp, I've updated the file Gitter.md to include a link to all available Gitter channels/rooms as requested in issue #843 . I moved the last paragraph of the original version below my addition so that it flows well when reading it. 


closes #843 