### PR TITLE
Article: How to keep a synced fork of our wiki

### DIFF
--- a/Wiki-Contribute-Fork.md
+++ b/Wiki-Contribute-Fork.md
@@ -1,13 +1,6 @@
-# Welcome to the Free Code Camp Wiki!
+# How to get a fork of our wiki and keep it syncronized
 
-Our open source community's Wiki focuses on answering your questions about learning to code and getting a coding job. We also cover in detail our:
-
-- Curriculum
-- Other Programming Languages
-- Local Campsite Communities
-- Nonprofit Projects and much more
-
-*Taste* the wiki at [**FreeCodeCamp/wiki**](https://github.com/FreeCodeCamp/FreeCodeCamp/wiki) :yum:
+These steps are standard for contributing not only to our wiki but any other project once you understand what is going on.
 
 ## Steps to follow
 

--- a/Wiki.md
+++ b/Wiki.md
@@ -42,6 +42,7 @@ You can also access them from Gitter using Camperbot
 We currently have a couple of guides to help you contribute, via the browser, command line or desktop application.
 
 - [How To Contribute From Your Browser:](Wiki-Contribute-Online) This is currently the easiest way we have to contribute. A simplified version can be found on [here](https://medium.freecodecamp.com/how-to-land-your-first-open-source-contribution-from-your-browser-in-15-minutes-756d9bbf81ad) also.
+- [How to fork our wiki](Wiki-Contribute-Fork) This will show you how to fork our wiki while being able to keep your fork syncronized.
 - [How To Contribute To The Wiki Locally:](Wiki-Contribute-Local-GUI) This is a guide that will show you how to have a local copy so you can make changes from your computer, it also works for contributing to the main repository.
 - [Pull Request Guidelines](PULL_REQUEST_TEMPLATE)
 - [More on how to make a pull request from a fork](Pull-Request-Contribute)


### PR DESCRIPTION
1. Update README to change ``##` to `## Steps to follow` (The blank `##` looks too weird/ugly but it serves to controlw hat's displayed at once on gitter chat.
2. Basically copy most of the content with minimal changes into an article we can point to and expand in the future at will beyond the basic capabilities. Maybe make it more general by not having it point to FCC or wiki.
3. Adds the link to the wiki central.