### PR TITLE
improve clarity of wiki articles, including label descriptions

### DIFF
--- a/Select-Issues-for-Contributing-Using-Labels.md
+++ b/Select-Issues-for-Contributing-Using-Labels.md
@@ -1,42 +1,42 @@
-In this article you can find labels (see the table below) used to categorize the variety of issues submitted to FCC. The labels range from **bugs** to **questions** to **curriculum requests**. For example, if an issue has a ***Wiki*** label, you can create a Wiki article about that issue - after reading the [Wiki Style Guide](Wiki-Style-Guide). 
+In this article you can find labels (see the table below) used to categorize the variety of issues submitted to FCC, along with descriptions (work in progress). The labels range from **bugs** to **questions** to **curriculum requests**. For example, if an issue has a ***Wiki*** label, you can create a wiki article about that issue—after reading the [Wiki Style Guide](Wiki-Style-Guide). 
 
-You can use labels to help you choose which issues to click on, rather than randomly clicking to find one of interest to you. Of course, you can work on and submit PRs for issues without labels. How ever you choose an issue, please be sure to read [Guidelines for Contributing](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md) before submitting any pull requests.
+You can use labels to help you choose which issues to click on, rather than randomly clicking to find one of interest to you. Of course, you can work on and submit PRs for issues without labels. However you choose an issue, please be sure to read the [Guidelines for Contributing](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md) before submitting any pull requests.
 
-Check out the table below for the list of FreeCodeCamp issue labels, along with descriptions (work in progress). Thanks @bugron, @ahstro, @benschenker, for compiling this list of labels and descriptions.
+Thanks @bugron, @ahstro, @benschenker, for compiling this list of labels and descriptions.
 
 Note: The labels ***blocked***, ***confirmed***, and ***QA*** are also tied to [Waffle](https://waffle.io/freecodecamp/freecodecamp), a management system for FCC (GitHub) issues, and are automatically added and removed by it.
 
 | Label              | Description | 
 | ------------------ | ----------- | 
-| accessibility      | This is used for issues that don't necessarily break the site, but make it harder to use (like when tests used to evaluate while you typed would flicker the whole screen). Also, relevant to enabling the site to be usable for those who may have vision impairment or disabilities.|
-| accounts           | Camper has a problem with his/her FCC account, such as login problems, losing progress, or profile page is missing some solutions.|
-| beta               | The issue is related to FCC's beta site.|
-| bike shedding      | Requests which are trivial or essentially irrelevant to the purposes of the site. In other words issues that have no real consequence yet people insist on spending cycles on them.|
-| blocked            | When an issue should not be worked on, due to waiting for the creator’s response, more information, or the issue is stale.|
-| bug                | Confirmed and reproducible bug in FCC's code and not only, for example, in Internet Explorer.
-| chrome             | The issue can only be reproduced in Google Chrome.|
-| confirmed          | The reported issue has been verified. (It basically says the issue creator has successfully communicated how to replicate the issue, but no one has started working toward a fix).|
-| curriculum request | Relates to everything that is requested to be added to current curriculum. The issue requests a new challenge, adding more explanation to a challenge, etc.|
-| device specific    | The issue presents only for a particular device (smartphone, tablet, desktop, etc).|
-| Discussing         | The issue is currently on discussion stage. |
-| duplicate          | The issue is a duplicate of another issue and most likely will be closed.|
-| easy               | This is used to flag issues that aren't critical, but should be easy for a camper to fix for their first couple of PRs. Think of these as the camper gateway to becoming a contributor. |
+| accessibility      | The issue doesn’t necessarily break the site, but it makes it harder to use (for example, tests used to evaluate while you typed, which would cause the whole screen to flicker). This label also marks improvements to the site’s usability for people with vision impairment or other disabilities.|
+| accounts           | A camper has a problem with his/her FCC account, such as login problems, losing progress, or a profile page that is missing some solutions.|
+| beta               | The issue is related to FCC’s beta site.|
+| bike shedding      | The request is are trivial or essentially irrelevant to the purposes of the site. In other words, issues that have no real consequence, yet which people insist on spending cycles on.|
+| blocked            | An issue that should not be worked on, while awaiting the creator’s response or more information, or because the issue is stale.|
+| bug                | A confirmed and reproducible bug in FCC’s code that occurs not only, for example, in Internet Explorer.
+| chrome             | The issue can be reproduced only in Google Chrome.|
+| confirmed          | The reported issue has been verified. (It basically says the issue creator has successfully communicated how to replicate the issue, but no one has started working toward a fix.)|
+| curriculum request | Anything that is requested to be added to current curriculum—for example, requesting a new challenge, adding more explanation to a challenge, etc.|
+| device specific    | The issue presents only for a particular device (smartphone, tablet, desktop, etc.).|
+| Discussing         | This issue is currently at the discussion stage. |
+| duplicate          | This issue duplicates another issue and most likely will be closed.|
+| easy               | This issue is not critical but should be easy for a camper to fix within their first couple of PRs. Think of these as the camper’s gateway to becoming a contributor. |
 | enhancement        | Similar to a Feature Request, but more related to improving existing features rather than adding new ones.|
-| feature request    | A request to add a feature to FCC. For example, ability to edit or remove Algorithms from campers profile page.|
-| firefox            | The issue can only be reproduced in Mozilla Firefox.|
+| feature request    | A request to add a feature to FCC. For example, a request to add the ability to edit or remove Algorithms from a camper’s profile page.|
+| firefox            | The issue can be reproduced only in Mozilla Firefox.|
 | help wanted        | Owners or issue moderators need campers’ help to investigate or fix the issue.|
-| hikes              | The issue is related to Hikes (they are currently not available in curriculum).|
-| ie/edge            | The issue can only be reproduced in Internet Explorer or Microsoft Edge. FCC officially supports only Google Chrome.|
+| hikes              | The issue is related to Hikes (which are not currently available in the curriculum).|
+| ie/edge            | The issue can be reproduced only in Internet Explorer or Microsoft Edge. FCC officially supports only Google Chrome.|
 | in progress        | Someone is currently making a fix for the issue.|
 | must start ASAP    | This issue needs to be reviewed/resolved as soon as possible.|
-| on the roadmap     | Generally feature requests that are planned to be implemented in future updates and/or will be implemented in near future.|
-| QA                 | (Quality Assurance) When a fix has been submitted and it needs to be reviewed before merging.|
+| on the roadmap     | Generally, a feature request that is planned to be implemented in future updates or that will be implemented in the near future.|
+| QA                 | (Quality Assurance) A fix has been submitted and needs to be reviewed before merging.|
 | question           | The issue is a question.|
-| reactify           | Issues related to moving to reactjs.|
+| reactify           | The issue is related to moving to reactjs.|
 | resolved           | The issue is resolved/fixed.|
 | tests              | The issue should be fixed with a test improvement, meaning someone needs to fix asserts.|
 | todo               | Something that needs to be done in future.|
-| translation        | This type of issues are either translation requests or issues related to an already implemented translation.|
-| ux                 | (User Experience) Similar to accessibility, but focuses on an issue where campers share their experience or with an issue that leads to a negative user experience. For example, tag is used when something may be too complicated or how to use a feature is difficult to understand.|
-| wiki               | Relates to FCC's GitHub Wiki articles. May be a request to create one. |
-| wontfix            | The issue is not fixable or will not be fixed in near future. An example of could be MS Edge browser support.|
+| translation        | The issue is either a translation request or related to an already implemented translation.|
+| ux                 | (User Experience) Similar to accessibility, but less about whether something is difficult to use than it is about campers’ experiencing an issue that leads to a negative user experience. For example, this tag is used when something may be too complicated or when the use of a feature is difficult to understand.|
+| wiki               | Relates to FCC’s GitHub Wiki articles. May be a request to create one. |
+| wontfix            | The issue is not fixable or will not be fixed in near future. For example, adding support for the MS Edge browser.|

--- a/Wiki-Style-Guide.md
+++ b/Wiki-Style-Guide.md
@@ -1,19 +1,19 @@
-# What Does "Wiki" Means?
+# What Does “Wiki” Mean?
 
-"Wiki" is a Hawaiian word meaning "quick". Keep this in mind when creating wiki articles. We are always happy to help new contributors write, edit, and localize our wiki articles. Help us make Free Code Camp the best it can be.
+“Wiki” is a Hawaiian word meaning “quick.” Keep this in mind when creating wiki articles. We are always happy to help new contributors write, edit, and localize our wiki articles. Help us make Free Code Camp the best it can be!
 
-You can create a new wiki page by clicking the "New Page" button at top right.
+You can create a new wiki page by clicking the “New Page” button at top right.
 
 Keep your wiki articles short and focused.
 
 You can include images if they help you better communicate your subject.
 
-## Use descriptive, punctuation-free titles that follow a name convention as `Name of Page`.
+## Use descriptive, punctuation-free titles that follow the naming convention `Name of Page`.
 
-Our wiki articles are [written in GitHub-flavor Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
+Our wiki articles are written in [GitHub-flavored Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
 - [Algorithm Style Guide](Algorithm-Style-Guide)
 
-If you have questions about contributing to the Free Code Camp Wiki message [@rafase282](https://gitter.im/rafase282) in [Gitter](https://github.com/FreeCodeCamp/freecodecamp/wiki/Gitter)
+If you have questions about contributing to the Free Code Camp Wiki, message [@rafase282](https://gitter.im/rafase282) in [Gitter](https://github.com/FreeCodeCamp/freecodecamp/wiki/Gitter).
 
 We look forward to wiki-ing with you!

--- a/Wiki.md
+++ b/Wiki.md
@@ -21,13 +21,15 @@ Here you will find all wiki related information with regards to guidelines for c
 
 The Free Code Camp wiki exists to provide clear answers to common questions about Free Code Camp, learning to code, and getting a coding job. Please feel free to add relevant content to the wiki. Just be sure to search for a topic and see if it already exists before starting a new page.
 
-Individual Wiki's can be accessed from the main page, or from other linked Wiki pages.
+Individual Wikis can be accessed from the main page, or from other linked wiki pages.
 
-You can also access them from Gitter using Camperbot
+You can also access wiki pages from Gitter using Camperbot:
 
 - **`help $topic`**
 
-  Finds related materials to that topic, usually a page from the [wiki](https://github.com/FreeCodeCamp/freecodecamp/wiki). Examples: `help css` `help bootstrap`
+  Finds related materials to that topic, usually a page from the [wiki](https://github.com/FreeCodeCamp/freecodecamp/wiki). Examples:   
+   `help css`   
+   `help bootstrap`
 
 - **`topics`**
 
@@ -35,24 +37,25 @@ You can also access them from Gitter using Camperbot
 
 - **`find $topic`**
 
-  This will search for entries that include `$topic` in the title. Example: `find wiki`
+  This will search for entries that include `$topic` in the title. Example:   
+  `find wiki`
 
 ## Contribution Guides
 
-We currently have a couple of guides to help you contribute, via the browser, command line or desktop application.
+We currently have a couple of guides to help you contribute, via the browser, command line, or desktop application.
 
-- [How To Contribute From Your Browser:](Wiki-Contribute-Online) This is currently the easiest way we have to contribute. A simplified version can be found on [here](https://medium.freecodecamp.com/how-to-land-your-first-open-source-contribution-from-your-browser-in-15-minutes-756d9bbf81ad) also.
-- [How to fork our wiki](Wiki-Contribute-Fork) This will show you how to fork our wiki while being able to keep your fork syncronized.
-- [How To Contribute To The Wiki Locally:](Wiki-Contribute-Local-GUI) This is a guide that will show you how to have a local copy so you can make changes from your computer, it also works for contributing to the main repository.
+- [How to Contribute from Your Browser](Wiki-Contribute-Online): This is currently the easiest way we have to contribute. A simplified version can also be found in the Medium post “[How to land your first open source contribution, from your browser, in 15 minutes](https://medium.freecodecamp.com/how-to-land-your-first-open-source-contribution-from-your-browser-in-15-minutes-756d9bbf81ad).”
+- [How to Fork Our wiki](Wiki-Contribute-Fork): This shows you how to fork our wiki and keep your fork synchronized.
+- [How to Contribute to the Wiki Locally](Wiki-Contribute-Local-GUI): This guide shows you how to make changes to the wiki from a local copy on your computer; it also works for contributing to the main repository.
 - [Pull Request Guidelines](PULL_REQUEST_TEMPLATE)
-- [More on how to make a pull request from a fork](Pull-Request-Contribute)
-- [How to Squash Commits:](git-rebase#squashing-multiple-commits-into-one) We required only one commit per Pull Request unless otherwise specified by a moderator.
+- [More on How to Make a Pull Request from a Fork](Pull-Request-Contribute)
+- [How to Squash Commits](git-rebase#squashing-multiple-commits-into-one): We require only one commit per pull request, unless otherwise specified by a moderator.
 
 ### Labels
 
-Before creating your first pull request or starting your work as an issue moderator it is strongly suggested to get familiar with the [labels guide](Wiki-Labels-Guide). This will provide you with a through understanding on our labeling system so you can proper utilize it and keep a stable workflow.
+Before creating your first pull request or starting your work as an issue moderator, it is strongly suggested that you get familiar with the [labels guide](Wiki-Labels-Guide). This will provide you with a through understanding on our labeling system so you can use it properly and maintain a stable workflow.
 
-For labels on a global levels on FreeCodeCamp's repositories you can follow [this](Select-Issues-for-Contributing-Using-Labels) guide.
+For a list of labels used globally throughout FreeCodeCamp’s repositories, consult the guide “[Select Issues for Contributing Using Labels](Select-Issues-for-Contributing-Using-Labels).”
 
 ### Issues
 
@@ -63,13 +66,13 @@ Creating issues in general is simpler than creating a pull request.
 
 ### Moderators
 
-If you are really committed to contributing to the wiki and you would like to join the team and be able to merge pull request, create new labels, assign mods to specific pull request and more then just check the [requirements to become a wiki mod](Wiki-Become-A-Mod) and follow the instructions.
+If you are really committed to contributing to the wiki and  would like to join the team and be able to merge pull requests, create new labels, assign mods to specific pull requests, and more, then just check the [requirements to become a wiki mod](Wiki-Become-A-Mod) and follow the instructions.
 
-[**Improve someone's pull request:**](Wiki-Improve-PR) At some point while managing the influx of pull request, you will be faced with the choice of letting an old contribution die out because the improvements needed have not been applied, or you could take contribution and improve it while also keeping the initial contributor's work. Often times, the later is the best choice.
+[**Improve someone’s pull request**](Wiki-Improve-PR): At some point while managing the influx of pull requests, you will be faced with a choice between letting an old contribution die out because the improvements needed have not been applied, or improving the contribution yourself while also keeping the initial contributor’s work. The latter is often the best choice.
 
 ### Translation
 
-We aim to translate all our articles in as many languages as supported. For this, we need people willing to collaborate and translate articles. We have a series of articles that will help you get started and solve any issues.
+We aim to translate all our articles into as many languages as we can support. For this, we need people willing to collaborate and translate articles. We have a series of articles that will help you get started and solve any issues:
 
 - [**Translation Guides**](Translations-Guide)
 
@@ -79,16 +82,16 @@ We have a few templates for different aspects of the wiki, such as different art
 
 ### Article Templates
 
-These kind of templates are a guide to the creation of new articles such as algorithms challenges, and informational articles.
+These templates guide the creation of new articles such as algorithm challenges and informational articles.
 
 - [JavaScript Articles](Wiki-Template-JavaScript)
 - [Challenge Solutions](Wiki-Template-Challenge-Solution)
 
 ### Contribution Templates
 
-These templates are visible when you are trying to contribute to the Wiki. They will provide you with useful information, guides, and guidelines that you must follow to ensure a proper contribution.
+These templates are visible when you are trying to contribute to the Wiki. They provide useful information, guides, and guidelines that you must follow to ensure a proper contribution.
 
 - [Contributing](CONTRIBUTING)
 - [Pull Request](PULL_REQUEST_TEMPLATE)
 
-**This page is still under construction, feel free to contribute to it by linking existing resources or extending on the content of this page.**
+**This page is still under construction, feel free to contribute to it by linking to existing resources or expanding the content of this page.**


### PR DESCRIPTION
Fixed some typos, tidied up syntax and colloquialisms for readers whose first language might not be English, tried to make language and presentation more clear and consistent overall.

This doesn’t address any _officially_ submitted issues that I could find, but I write and proofread a lot of technical documentation in real life, so I figure this is one of the best ways I can contribute. I hope you don’t find it obnoxious! 😽

Sorry if my commits are not squashed. I’m not yet ready to face the horror that is command-line git.