### PR TITLE
Fixed link to DevTools page in ToC

### DIFF
--- a/Setting-Up-Ubuntu-For-Programming.md
+++ b/Setting-Up-Ubuntu-For-Programming.md
@@ -8,7 +8,7 @@
 
 [3. Jazzing up the Terminal](Ubuntu-Jazzing-up-the-Terminal)
 
-[4. Installing DevTools and modern web browsers](Ubuntu-Installing-DevTools-and-Modern-Web-Browsers)
+[4. Installing DevTools and modern web browsers](Ubuntu-Installing-DevTools)
 
 [5. Downloading Text Editors and IDEs](Ubuntu-Downloading-Text-Editors-and-IDEs)
 


### PR DESCRIPTION
The link in the ToC to was to a page that didn't exist. I've edited to point to the correct page. No idea why it is highlighting item 6, which I didn't touch.