### PR TITLE
Better titles for articles

### DIFF
--- a/CSS-Framework-Bootstrap.md
+++ b/CSS-Framework-Bootstrap.md
@@ -1,4 +1,4 @@
-# Bootstrap
+# CSS Franework Bootstrap
 
 Bootstrap is the most popular CSS framework for developing responsive, mobile first projects for the web.
 

--- a/CSS-Framework-Bootstrap.md
+++ b/CSS-Framework-Bootstrap.md
@@ -1,4 +1,4 @@
-# CSS Franework Bootstrap
+# CSS Framework Bootstrap
 
 Bootstrap is the most popular CSS framework for developing responsive, mobile first projects for the web.
 

--- a/CSS-Framework-Bulma.md
+++ b/CSS-Framework-Bulma.md
@@ -1,4 +1,4 @@
-# Bulma
+# CSS Franework Bulma
 
 Bulma is a modern CSS framework based on [Flexbox](CSS-Flexbox) and highly customizable using [Sass](http://sass-lang.com/) (SCSS).
 

--- a/CSS-Framework-Bulma.md
+++ b/CSS-Framework-Bulma.md
@@ -1,4 +1,4 @@
-# CSS Franework Bulma
+# CSS Framework Bulma
 
 Bulma is a modern CSS framework based on [Flexbox](CSS-Flexbox) and highly customizable using [Sass](http://sass-lang.com/) (SCSS).
 

--- a/CSS-Framework-Foundation.md
+++ b/CSS-Framework-Foundation.md
@@ -1,4 +1,4 @@
-# Foundation
+# CSS Franework Foundation
 
 [Foundation](http://foundation.zurb.com/) is the one of the most advanced responsive front-end frameworks.
 

--- a/CSS-Framework-Foundation.md
+++ b/CSS-Framework-Foundation.md
@@ -1,4 +1,4 @@
-# CSS Franework Foundation
+# CSS Framework Foundation
 
 [Foundation](http://foundation.zurb.com/) is the one of the most advanced responsive front-end frameworks.
 

--- a/CSS-Framework-Materialize.md
+++ b/CSS-Framework-Materialize.md
@@ -1,4 +1,4 @@
-# Materialize
+# CSS Franework Materialize
 
 Materialize is a Responsive CSS framework based on Google's [Material Design](https://design.google.com/spec/) Language.
 

--- a/CSS-Framework-Materialize.md
+++ b/CSS-Framework-Materialize.md
@@ -1,4 +1,4 @@
-# CSS Franework Materialize
+# CSS Framework Materialize
 
 Materialize is a Responsive CSS framework based on Google's [Material Design](https://design.google.com/spec/) Language.
 

--- a/CSS-Framework-Skeleton.md
+++ b/CSS-Framework-Skeleton.md
@@ -1,4 +1,4 @@
-# Skeleton
+# CSS Franework Skeleton
 
 Skeleton is a dead simple boilerplate to kickstart any responsive project.
 

--- a/CSS-Framework-Skeleton.md
+++ b/CSS-Framework-Skeleton.md
@@ -1,4 +1,4 @@
-# CSS Franework Skeleton
+# CSS Framework Skeleton
 
 Skeleton is a dead simple boilerplate to kickstart any responsive project.
 

--- a/Challenge-Get-Geo-Location-Data.md
+++ b/Challenge-Get-Geo-Location-Data.md
@@ -1,4 +1,4 @@
-# Challenge Get Geo-location Data
+# Challenge Get Geo location Data
 
 Every browser has a built in navigator that can give us this information.
 

--- a/Challenge-Get-Geo-Location-Data.md
+++ b/Challenge-Get-Geo-Location-Data.md
@@ -1,4 +1,4 @@
-# Challenge Get Geo location Data
+# Challenge Get Geo Location Data
 
 Every browser has a built in navigator that can give us this information.
 

--- a/Clojure-Basics.md
+++ b/Clojure-Basics.md
@@ -1,4 +1,4 @@
-# Clojure - The Basics
+# Clojure The Basics
 
 ### Getting Started
 

--- a/Clojure-Collections.md
+++ b/Clojure-Collections.md
@@ -1,4 +1,4 @@
-# Clojure - Collections
+# Clojure Collections
 
 One of Clojure's main positives is that it has quite a few different kinds of sequence: vectors, lists, hashmaps, _oh my!_ And each different type of collections has its own upsides, downsides, and a whole host of useful functions that operate on them.
 

--- a/Clojure-Conditionals.md
+++ b/Clojure-Conditionals.md
@@ -1,4 +1,4 @@
-# Clojure - Conditionals
+# Clojure Conditionals
 
 You're not going to get anywhere in a language if all you can do is define functions that print things and do simple arithmetic. Conditionals and logic are a fundamental part of making code that does interesting, useful things. Try and imagine a world without logic in programs: you wouldn't even be able to simple things, like checking if two numbers are equal!
 

--- a/Clojure-Functions.md
+++ b/Clojure-Functions.md
@@ -1,4 +1,4 @@
-# Clojure - More on Functions
+# Clojure More on Functions
 
 Functions! They're pretty important. It's very difficult to do anything without a function. They're integral to any language, but especially Clojure, since it's a functional programming language that rejects object-oriented design. Let's learn some more about them!
 

--- a/Clojure-Hashmaps.md
+++ b/Clojure-Hashmaps.md
@@ -1,4 +1,4 @@
-# Clojure - Hashmaps
+# Clojure Hashmaps
 
 A hashmap is a collection that maps keys to values. They have various names in other languages; Python refers to them as dictionaries, and Javascript's objects essentially work like hashmaps.
 

--- a/Clojure-Let-Bindings.md
+++ b/Clojure-Let-Bindings.md
@@ -1,4 +1,4 @@
-# Clojure - Let
+# Clojure Let
 
 `let` is a fundamental part of Clojure. Whereas `def` creates a global variable, `let` creates a local variable.
 
@@ -17,6 +17,8 @@
 ```
 
 :rocket: [IDEOne it!](https://ideone.com/xcNth2)
+
+##  
 
 `x` in this example never actually gets changed. `x` just refers to something different inside of our `let` binding. This can be a useful way to avoid repetition inside a function.
 

--- a/Clojure-Lists.md
+++ b/Clojure-Lists.md
@@ -1,4 +1,4 @@
-# Clojure - Lists
+# Clojure Lists
 
 Lists are fundamental to Clojure. Clojure is a Lisp, and Lisps were originally used for list processing. Everything in a Lisp is a list!
 

--- a/Design-Resources-For-Front-End-Developers.md
+++ b/Design-Resources-For-Front-End-Developers.md
@@ -1,4 +1,4 @@
-# Design Resources for Front-End Developers
+# Design Resources for Front End Developers
 
 Are you a freelance front-end web developer or are you thinking about becoming one? Maybe you've been to a coding bootcamp or graduated from an online front-end development course. What happens next?
 

--- a/FreeCodeCamp-Back-End-Development-Certification.md
+++ b/FreeCodeCamp-Back-End-Development-Certification.md
@@ -1,4 +1,4 @@
-# Here's how to earn our verified Back End Development Certification:
+# Here's how to earn our verified Back End Development Certification
 
 ![An image of a sample Back End Development Certification](http://i.imgur.com/oxFYeWd.png?1)
 

--- a/FreeCodeCamp-Data-Visualization-Certification.md
+++ b/FreeCodeCamp-Data-Visualization-Certification.md
@@ -1,4 +1,4 @@
-# Here's how to earn our verified Data Visualization Certification:
+# Here's how to earn our verified Data Visualization Certification
 
 ![An image of a sample Front End Development Certificate](http://i.imgur.com/HKPqdTF.png?1)
 

--- a/FreeCodeCamp-Front-End-Development-Certification.md
+++ b/FreeCodeCamp-Front-End-Development-Certification.md
@@ -1,4 +1,4 @@
-# Here's how to earn our verified Front End Development Certification:
+# Here's how to earn our verified Front End Development Certification
 
 ![An image of a sample Front End Development Certificate](http://i.imgur.com/UrU2ki8.png)
 

--- a/Git-Pull-Vs-Git-Fetch.md
+++ b/Git-Pull-Vs-Git-Fetch.md
@@ -1,4 +1,4 @@
-# Git Pull vs Git Fetch:
+# Git Pull vs Git Fetch
 
 These two commands are regularly used by git users. Let's see the difference between both commands.
 

--- a/GitHub-Hosting.md
+++ b/GitHub-Hosting.md
@@ -1,4 +1,4 @@
-# Use GitHub Static pages to host your Front-End Projects
+# Use GitHub Static pages to host your Front End Projects
 
 **Benefits**
 

--- a/IIFE.md
+++ b/IIFE.md
@@ -1,4 +1,4 @@
-# IIFE — Initialism for Immediately Invoked Function Expression
+# IIFE Initialism for Immediately Invoked Function Expression
 
 Keep your data inside the [closure](JS-Closures)!
 

--- a/Install-Django-Flask.md
+++ b/Install-Django-Flask.md
@@ -1,4 +1,4 @@
-# Setting Up Python Web-framework: Django and Flask
+# Setting Up Python Web-framework Django and Flask
 
 [Previous](Web-Development-in-Python)
 

--- a/Python-Big-O.md
+++ b/Python-Big-O.md
@@ -1,4 +1,4 @@
-# Big O?
+# Python Big O
 
 **TODO: Find external big-O resource?**
 

--- a/Python-Code-Blocks.md
+++ b/Python-Code-Blocks.md
@@ -1,4 +1,4 @@
-# Code Blocks and Indentation
+# Python Code Blocks and Indentation
 
 [Indentation](https://docs.python.org/3/reference/lexical_analysis.html#indentation)
 

--- a/Python-Constants.md
+++ b/Python-Constants.md
@@ -1,4 +1,4 @@
-# Python Built-in Constants
+# Python Built in Constants
 
 [Constants](https://docs.python.org/3/library/constants.html)
 

--- a/Python-Functions-Aliasing-Name-Binding.md
+++ b/Python-Functions-Aliasing-Name-Binding.md
@@ -1,4 +1,4 @@
-# Name binding and Aliasing Functions
+# Python Name binding and Aliasing Functions
 
 A function definition introduces the function name in the current symbol table. The value of the function name has a type that is recognized by the interpreter as a user-defined function.
 

--- a/Python-Functions-Calling.md
+++ b/Python-Functions-Calling.md
@@ -1,4 +1,4 @@
-# Calling Functions
+# Python Calling Functions
 
 A function definition statement does not execute the function. Executing (calling) a function is done by using the name of the function followed by parenthesis enclosing required arguments (if any).
 

--- a/Python-Functions-Defining.md
+++ b/Python-Functions-Defining.md
@@ -1,4 +1,4 @@
-# Defining Functions
+# Python Defining Functions
 
 [Python Docs](https://docs.python.org/3/tutorial/controlflow.html#defining-functions)
 

--- a/Python-Functions-Expressions-Lambda.md
+++ b/Python-Functions-Expressions-Lambda.md
@@ -1,4 +1,4 @@
-# Lambda Expressions
+# Python Lambda Expressions
 
 [Python Docs - Lambda](https://docs.python.org/3/reference/expressions.html?highlight=lambda%20expressions#lambda)
 

--- a/Python-Functions-Nested.md
+++ b/Python-Functions-Nested.md
@@ -1,4 +1,4 @@
-# Nested functions
+# Python Nested functions
 
 ```python
 >>> def outside_fn():

--- a/Python-Functions-Statements-Global.md
+++ b/Python-Functions-Statements-Global.md
@@ -1,4 +1,4 @@
-# The global Statement
+# Python The global Statement
 
 [Python Docs - the Global Statement](https://docs.python.org/3/reference/simple_stmts.html#the-global-statement)
 

--- a/Python-Functions-Statements-Nonlocal.md
+++ b/Python-Functions-Statements-Nonlocal.md
@@ -1,4 +1,4 @@
-# The nonlocal Statements
+# Python The nonlocal Statements
 
 [Python Docs - the nonlocal Statement](https://docs.python.org/3/reference/simple_stmts.html#the-nonlocal-statement)
 

--- a/Python-Functions.md
+++ b/Python-Functions.md
@@ -1,4 +1,4 @@
-# Functions
+# Python Functions
 
 [Previous](Python-Operators)
 

--- a/Python-Introduction.md
+++ b/Python-Introduction.md
@@ -1,4 +1,4 @@
-# Introduction
+# Python Introduction
 
 [Previous](Python)
 
@@ -149,6 +149,3 @@ The argument that we called the `print` function with is a `str` object or *stri
 The `objects` parameter is prefixed with a `*` which indicates that the function will take an arbitrary number of arguments for that parameter.
 
 We shall now continue with [Python Basics](Python-Basics)
-
-
-

--- a/Python-Keywords.md
+++ b/Python-Keywords.md
@@ -1,4 +1,4 @@
-# Keywords are Reserved
+# Python Keywords
 
 Python has a list of [keywords](https://docs.python.org/3/reference/lexical_analysis.html#keywords) that cannot be used as identifiers (variable names):
 

--- a/Python-Mapping-Dict-Creation.md
+++ b/Python-Mapping-Dict-Creation.md
@@ -1,4 +1,4 @@
-# Python Creation:
+# Python Creation
 
 `dict` literal:
 

--- a/Python-Mapping-Dict-Examples.md
+++ b/Python-Mapping-Dict-Examples.md
@@ -1,4 +1,4 @@
-# Python Examples:
+# Python Examples
 
 **To-Do**
 

--- a/Python-Mapping-Dict-Methods.md
+++ b/Python-Mapping-Dict-Methods.md
@@ -1,4 +1,4 @@
-# Python Methods:
+# Python Methods
 
 **TODO: [Python Docs - Dictionary View Objects](https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects)**
 

--- a/Python-Mapping-Dict-Uses.md
+++ b/Python-Mapping-Dict-Uses.md
@@ -1,4 +1,4 @@
-# Python Uses:
+# Python Uses
 
 **To-Do**
 

--- a/Python-More-Builtin-Types.md
+++ b/Python-More-Builtin-Types.md
@@ -1,4 +1,4 @@
-# More Built-in Types
+# Python More Built-in Types
 
 [Previous](Python-Operators)
 

--- a/Python-Mutability.md
+++ b/Python-Mutability.md
@@ -1,4 +1,4 @@
-# Mutability and Variable Assignments
+# Python Mutability and Variable Assignments
 
 > Every object has an identity, a type and a value. An object's identity never changes once it has been created; you may think of it as the object's address in memory. [source](https://docs.python.org/3/reference/datamodel.html#data-model)
 

--- a/Python-Numeric-Types.md
+++ b/Python-Numeric-Types.md
@@ -1,4 +1,4 @@
-# Numeric Types
+# Python Numeric Types
 
 The [numeric types](https://docs.python.org/3/library/stdtypes.html#numeric-types-int-float-complex) for Python are:
 

--- a/Python-Objects.md
+++ b/Python-Objects.md
@@ -1,4 +1,4 @@
-# Objects
+# Python Objects
 
 > In Python, everything is an _object_.
 

--- a/Python-Operators.md
+++ b/Python-Operators.md
@@ -1,4 +1,4 @@
-# Operations and Operators
+# Python Operations and Operators
 
 [Previous](Python-Basics)
 

--- a/Python-Range.md
+++ b/Python-Range.md
@@ -1,4 +1,4 @@
-# Range
+# Python Range
 
 **TODO: `range` basic info**
 

--- a/Python-Scope.md
+++ b/Python-Scope.md
@@ -1,4 +1,4 @@
-# Scopes
+# Python Scopes
 
 **TODO: NOTE**
 

--- a/Python-Tuples.md
+++ b/Python-Tuples.md
@@ -1,4 +1,4 @@
-# Tuples
+# Python Tuples
 
 **TODO: `Tuple` basic info**
 

--- a/Python-Variables.md
+++ b/Python-Variables.md
@@ -1,4 +1,4 @@
-# Variables, Names, and Binding
+# Python Variables, Names, and Binding
 
 Having _objects_ isn't useful unless there is a way to use them. In order to use an _object_, there must be a way to reference them. In Python this is done by **binding** objects to **names**. A detailed overview of can be found [here](https://docs.python.org/3/reference/executionmodel.html)
 

--- a/Python-Web-Frameworks-Usage.md
+++ b/Python-Web-Frameworks-Usage.md
@@ -1,4 +1,4 @@
-# Web Frameworks and What They Do For You
+# Python Web Frameworks and What They Do For You
 
 We have used the word `framework` quite librarily in the earlier articles. You might or might not be familiar with what that is. Nonetheless, we would discuss what Python Web Frameworks do for you, out-of-the-box.
 

--- a/Ruby-Introduction.md
+++ b/Ruby-Introduction.md
@@ -1,4 +1,4 @@
-# Introduction
+# Ruby Introduction
 
 [Previous](Ruby)
 

--- a/Ruby-Strings.md
+++ b/Ruby-Strings.md
@@ -1,6 +1,6 @@
 # Ruby Strings
 
-## Basics:
+### Basics:
 
 - Strings are a series of characters 'strung' together between quotes.
 - Single or double quotes can be used to create strings in Ruby.

--- a/Translation-Translate.md
+++ b/Translation-Translate.md
@@ -1,4 +1,4 @@
-# Do Translations.
+# Start Translating
 
 When you want to work on any of the translations, we encourage you to leave a comment like `"Working on it"` on the [open/ongoing translation issues](https://github.com/FreeCodeCamp/FreeCodeCamp/issues?q=is%3Aissue+is%3Aopen+label%3Atranslation). This will notify the contributors about your interest in doing the translation.
 


### PR DESCRIPTION
Removes `-` and `:` from titles and also makes sure titles are more self explanatory.