### PR TITLE
Change Wiki-Central Link 

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -28,7 +28,7 @@ If we merge your pull request, your name will be automatically added to the docu
 
 ### Guides on how to Contribute
 
-They are all located on our [Wiki Central](Wiki-Central) Page. Please take a look before anything else.
+They are all located on our [Wiki Central](https://freecodecamp.github.io/wiki/en/wiki-central) Page. Please take a look before anything else.
 
 If you have questions about contributing to the Free Code Camp Wiki message [@Rafase282 in Gitter](https://gitter.im/Rafase282) or come the [Gitter Wiki Room.](https://gitter.im/FreeCodeCamp/Wiki)
 


### PR DESCRIPTION

When navigating to FCC.com and clicking wiki it shows the side bar (wiki). scrolling to the bottom of the side bar and clicking wiki-central take you to a 404 page due to the link being in capital letter. 

I changed the link to contain only lowercase letters. 

Please be considerate with me as this is my first pull request. 
Thanks