### PR TITLE
Fix a bug in palindrome challenge

### DIFF
--- a/Algorithm-Check-For-Palindromes.md
+++ b/Algorithm-Check-For-Palindromes.md
@@ -101,7 +101,7 @@ function palindrome(str) {
 ```javascript
 function palindrome(str) {
 // make all letters lowercase and remove non-alphanumeric characters
-  str = str.toLowerCase().replace(/[^a-z|1-9]/g, "");
+  str = str.toLowerCase().replace(/[^a-z|0-9]/g, "");
 
   // if the length of the string is 0 then it is a palindrome
   if (str.length === 0){


### PR DESCRIPTION
I noticed a bug while helping out a camper in our FCC Hyderabad meetup. The RegEx should be `0-9`, not `1-9`. Otherwise, it would exclude 0 as an alphanumeric character.