### PR TITLE
Fix broken internal link

### DIFF
--- a/Python-Web-Frameworks.md
+++ b/Python-Web-Frameworks.md
@@ -4,4 +4,4 @@ Like most domains in Python development, the Python community treats web-develop
 
 We have micro-frameworks like [Flask](http://flask.pocoo.org/), [Bottle](http://bottlepy.org/docs/dev/index.html). We also have frameworks like [Django](https://www.djangoproject.com/), which comes with [batteries included](https://github.com/rosarior/awesome-django). You can find a complete list of web-frameworks, written in Python, [over here](https://en.wikipedia.org/wiki/Comparison_of_web_frameworks#Python).
 
-[Previous](Web-Development-in-Python)
+[Previous](Web-Development-in-Python.md)


### PR DESCRIPTION
Internal links using \[example](filename) leads to 404. You have to to \[example](filename.md) instead.

**filename** is the name of a markdown file on the same level.