### PR TITLE
Updated Map wiki page to fix Algorithm-Where-Art-Thou link

### DIFF
--- a/deprecated wiki/Map.md
+++ b/deprecated wiki/Map.md
@@ -317,7 +317,7 @@
 - [Algorithm: Sum All Numbers in a Range](Algorithm-Sum-All-Numbers-In-A-Range)
 - [Algorithm: Diff Two Arrays](Algorithm-Diff-Two-Arrays)
 - [Algorithm: Roman Numeral Converter](Algorithm-roman-numeral-converter)
-- [Algorithm: Where art thou](Algorithm-Where-Art-Thou)
+- [Algorithm: Wherefore art thou](Algorithm-Wherefore-Art-Thou)
 - [Algorithm: Search and Replace](Algorithm-Search-And-Replace)
 - [Algorithm: Pig Latin](Algorithm-Pig-Latin)
 - [Algorithm: DNA Pairing](Algorithm-DNA-Pairing)


### PR DESCRIPTION
The Algorithm-Where-Art-Thou pointed to the wiki page
Algorithm-Where-Art-Thou, which does not exist. The correct wiki page is
Algorithm-Wherefore-Art-Thou, so I updated the text for the link to
match the name of the challenge as it appears on FCC's website and
updated the link as well to point to the existing page.
